### PR TITLE
Clicking next or back too fast

### DIFF
--- a/src/components/SelectAlbum/SelectAlbum.tsx
+++ b/src/components/SelectAlbum/SelectAlbum.tsx
@@ -1,31 +1,60 @@
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { selectAlbumAnimationDuration, setShowAlbum } from "../../slices/menuSlice";
-import { nextAlbum, prevAlbum } from "../../slices/spotifySlice";
+import { selectAlbumAnimationDuration, setNextDisabled, setPrevDisabled, setShowAlbum } from "../../slices/menuSlice";
+import { nextAlbum, prevAlbum, selectCurrentAlbum, selectTracks } from "../../slices/spotifySlice";
 import SelectAlbumComp from "./SelectAlbumComp";
 
 const SelectAlbum = () => {
     
     const dispatch = useDispatch();
     const duration = useSelector(selectAlbumAnimationDuration);
+    const tracks = useSelector(selectTracks);
+    const curretAlbum = useSelector(selectCurrentAlbum);
     
+    useEffect(() => {
+        if (curretAlbum === 0) {
+            dispatch(setPrevDisabled(true));
+        } else{
+            dispatch(setPrevDisabled(false));
+        }
+
+        if(curretAlbum === tracks.length-1){
+            dispatch(setNextDisabled(true));
+        }else{
+            dispatch(setNextDisabled(false));
+        }
+    },[tracks, curretAlbum, dispatch])
+
+
     const handleNextClick = () => {
-        dispatch(setShowAlbum(false));
-        setTimeout(() => {
-            dispatch(nextAlbum());
-            dispatch(setShowAlbum(true))
-        },duration)
+        if(curretAlbum+1 < tracks.length-1){
+            dispatch(setShowAlbum(false));
+            setTimeout(() => {
+                dispatch(nextAlbum());
+                dispatch(setShowAlbum(true));
+            },duration)
+        } else{
+            dispatch(setNextDisabled(true));
+        }
     }
 
     const handlePrevClick = () => {
-        dispatch(setShowAlbum(false));
-        setTimeout(() => {
-            dispatch(prevAlbum());
-            dispatch(setShowAlbum(true))
-        },duration)
+        if (curretAlbum-1 > -1) {
+            dispatch(setShowAlbum(false));
+            setTimeout(() => {
+                dispatch(prevAlbum());
+                dispatch(setShowAlbum(true))
+            },duration)
+        }else {
+            dispatch(setPrevDisabled(true));
+        }
+        
     }
 
     return(
         <SelectAlbumComp
+            tracks={tracks}
+            curretAlbum={curretAlbum}
             handleNextClick={handleNextClick}
             handlePrevClick={handlePrevClick}
         />

--- a/src/components/SelectAlbum/SelectAlbum.tsx
+++ b/src/components/SelectAlbum/SelectAlbum.tsx
@@ -27,7 +27,7 @@ const SelectAlbum = () => {
 
 
     const handleNextClick = () => {
-        if(curretAlbum+1 < tracks.length-1){
+        if(curretAlbum+1 < tracks.length){
             dispatch(setShowAlbum(false));
             setTimeout(() => {
                 dispatch(nextAlbum());

--- a/src/components/SelectAlbum/SelectAlbumComp.tsx
+++ b/src/components/SelectAlbum/SelectAlbumComp.tsx
@@ -2,20 +2,24 @@ import { Grid, IconButton, Grow, Typography } from "@mui/material";
 import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import { useSelector } from "react-redux";
-import { selectCurrentAlbum, selectTracks } from "../../slices/spotifySlice";
-import { selectAlbumAnimationDuration, selectShowAlbum } from "../../slices/menuSlice";
+import { selectAlbumAnimationDuration, selectIsNextDisabled, selectIsPrevDisabled, selectShowAlbum } from "../../slices/menuSlice";
+import { GenericObject } from "../../types";
 
 interface props {
-    handleNextClick: () => void
-    handlePrevClick: () => void
+    tracks:GenericObject[],
+    curretAlbum:number,
+    handleNextClick: () => void,
+    handlePrevClick: () => void,
 }
 
-const SelectAlbumComp = ({handleNextClick,handlePrevClick}:props) => {
+const SelectAlbumComp = ({curretAlbum,tracks,handleNextClick,handlePrevClick}:props) => {
 
-   const tracks = useSelector(selectTracks);
-   const curretAlbum = useSelector(selectCurrentAlbum);
-   const duration = useSelector(selectAlbumAnimationDuration);
-   const showAlbum = useSelector(selectShowAlbum);
+//    const tracks = useSelector(selectTracks);
+//    const curretAlbum = useSelector(selectCurrentAlbum);
+    const isNextDisabled = useSelector(selectIsNextDisabled);
+    const isPrevDisabled = useSelector(selectIsPrevDisabled);
+    const duration = useSelector(selectAlbumAnimationDuration);
+    const showAlbum = useSelector(selectShowAlbum);
 
     return(
         <Grid container spacing={2}>
@@ -24,7 +28,7 @@ const SelectAlbumComp = ({handleNextClick,handlePrevClick}:props) => {
                     color="primary" 
                     aria-label="previos"
                     onClick={handlePrevClick}
-                    disabled={curretAlbum === 0 ? true : false}
+                    disabled={isPrevDisabled}
                 >
                     <ArrowLeftIcon fontSize="large"/>
                 </IconButton>
@@ -44,7 +48,7 @@ const SelectAlbumComp = ({handleNextClick,handlePrevClick}:props) => {
                     color="primary" 
                     aria-label="next"
                     onClick={handleNextClick}
-                    disabled={curretAlbum === tracks.length-1 ? true : false} 
+                    disabled={isNextDisabled} 
                 >
                     <ArrowRightIcon fontSize="large"/>
                 </IconButton>

--- a/src/components/TimeRangeButtons/TimeRangeButtons.tsx
+++ b/src/components/TimeRangeButtons/TimeRangeButtons.tsx
@@ -8,6 +8,9 @@ const TimeRangeButtons = () => {
 
 
     const handleChange = (event:React.MouseEvent<HTMLElement>,timeRangeString:string) => {
+        if (timeRangeString === null){
+            timeRangeString = 'short_term'
+        }
         dispatch(setTimeRange(timeRangeString))
     }
 

--- a/src/slices/menuSlice.ts
+++ b/src/slices/menuSlice.ts
@@ -1,15 +1,19 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface MenuState {
     open:boolean,
     showAlbum:boolean,
     albumAnimationDuration:number,
+    isPrevDisabled:boolean,
+    isNextDisabled:boolean,
 }
 
 const initialState = {
     open:false,
     showAlbum:true,
     albumAnimationDuration:300,
+    isPrevDisabled:true,
+    isNextDisabled:false,
 } as MenuState;
 
 const menuSlice = createSlice({
@@ -21,14 +25,23 @@ const menuSlice = createSlice({
         },
         setShowAlbum(state,action){
             state.showAlbum = action.payload;
-        }
+        },
+        setPrevDisabled(state,action:PayloadAction<boolean>){
+            state.isPrevDisabled = action.payload;
+        },
+        setNextDisabled(state,action:PayloadAction<boolean>){
+            state.isNextDisabled = action.payload;
+        },
+
     }
 })
 
 export const selectMenuOpen = (state: { menu: { open: boolean; }; }) => state.menu.open;
 export const selectShowAlbum = (state: { menu: { showAlbum: boolean; }; }) => state.menu.showAlbum;
 export const selectAlbumAnimationDuration = (state: { menu: { albumAnimationDuration: number; }; }) => state.menu.albumAnimationDuration;
+export const selectIsPrevDisabled = (state: { menu: { isPrevDisabled: boolean; }; }) => state.menu.isPrevDisabled;
+export const selectIsNextDisabled = (state: { menu: { isNextDisabled: boolean; }; }) => state.menu.isNextDisabled;
 
-export const {toggleMenu,setShowAlbum} = menuSlice.actions;
+export const {toggleMenu,setShowAlbum,setPrevDisabled,setNextDisabled} = menuSlice.actions;
 
 export default menuSlice.reducer;

--- a/src/slices/menuSlice.ts
+++ b/src/slices/menuSlice.ts
@@ -8,8 +8,6 @@ interface MenuState {
 
 const initialState = {
     open:false,
-    nextAlbum:false,
-    prevAlbum:true,
     showAlbum:true,
     albumAnimationDuration:300,
 } as MenuState;

--- a/src/slices/spotifySlice.ts
+++ b/src/slices/spotifySlice.ts
@@ -115,10 +115,14 @@ const spotifySlice = createSlice({
             state.showGraph = action.payload;
         },
         nextAlbum(state){
-            state.currentAlbum++;
+            if (state.currentAlbum+1 < state.tracks.length-1) {
+                state.currentAlbum++;
+            }
         },
         prevAlbum(state){
-            state.currentAlbum--;
+            if(state.currentAlbum-1 > -1){
+                state.currentAlbum--;
+            }
         },
         setCurrentAlbum(state,action){
             state.currentAlbum = action.payload;

--- a/src/slices/spotifySlice.ts
+++ b/src/slices/spotifySlice.ts
@@ -115,7 +115,7 @@ const spotifySlice = createSlice({
             state.showGraph = action.payload;
         },
         nextAlbum(state){
-            if (state.currentAlbum+1 < state.tracks.length-1) {
+            if (state.currentAlbum+1 < state.tracks.length) {
                 state.currentAlbum++;
             }
         },


### PR DESCRIPTION
### What?
Fixed bug where user clicked next or back too fast, it throwed an error.

Also fixed that if currentAlbum was above number of tracks it would throw an error.

### Why? 
bugs need to be squashed

### How?
Prevented currented current album from going above or below track states. 

Reset the album to the be the first when number tracks changes. 
