### PR TITLE
Make less api calls

### DIFF
--- a/src/components/Histogram/Histogram.tsx
+++ b/src/components/Histogram/Histogram.tsx
@@ -33,7 +33,7 @@ const Histogram = () => {
 
     const yScale = scaleBand()
       .domain(tracks.map(d => d.shortName).reverse())
-      .range([height,20])
+      .range([height + 20,20])
       .padding(.10);
 
     const xScale = scaleLinear()

--- a/src/components/Histogram/XYAxis.tsx
+++ b/src/components/Histogram/XYAxis.tsx
@@ -35,7 +35,7 @@ const XYAxis = ({ xScale, yScale }:props) => {
         select(xAxis.current || '').select('.domain').attr('stroke',themeColors.backgroundColor.fontColor);
         select(xAxis.current || '').selectAll('.tick line').attr('stroke',themeColors.backgroundColor.fontColor);
         select(xAxis.current || '').selectAll('.tick text').attr('fill',themeColors.backgroundColor.fontColor);
-    },[themeColors.backgroundColor.fontColor])
+    },[themeColors.backgroundColor.fontColor,tracks])
 
 
     return (

--- a/src/components/LoggedInScreen.tsx
+++ b/src/components/LoggedInScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useDispatch,useSelector } from "react-redux";
 import { AppDispatch } from "../app/store";
 import { selectNumOfTracks, selectTimeRange } from "../slices/filterButtonsSlice";
-import { fetchTopTracks, selectShowGraph, setCurrentTracks } from "../slices/spotifySlice";
+import { fetchTopTracks, selectAllLongRangeTracks, selectAllShortRangeTracks, selectShowGraph, setCurrentTracks } from "../slices/spotifySlice";
 import Histogram from "./Histogram/Histogram";
 import NumOfTrackSlider from "./NumOfTrackSlider/NumNumOfTrackSlider";
 import SelectAudiFeature from "./SelectAudioFeature/SelectAudiFeature";
@@ -16,17 +16,30 @@ const LoggedInScreen = () => {
     const timeRange = useSelector(selectTimeRange);
     const numOfTracks = useSelector(selectNumOfTracks);
     const showGraph = useSelector(selectShowGraph);
+    const allShortRangeTracks = useSelector(selectAllShortRangeTracks);
+    const allLongRangeTracks = useSelector(selectAllLongRangeTracks);
+
     
-    useEffect(() => {
-        dispatch(fetchTopTracks({timeRange}));     
-    },[dispatch,timeRange]);
+    
+    // useEffect(() => {
+    //     dispatch(fetchTopTracks({timeRange}));     
+    // },[dispatch,timeRange]);
 
     useEffect(() => {
         const delayChange = setTimeout(() => {
-            dispatch(setCurrentTracks({timeRange:timeRange,numOfTracks:numOfTracks}));
+            if (timeRange ==='short_term' && allShortRangeTracks.length > 0) {
+                dispatch(setCurrentTracks({timeRange:'allShortRangeTracks',numOfTracks:numOfTracks}));
+            } else if(timeRange ==='medium_term'){
+                dispatch(setCurrentTracks({timeRange:'allMedRangeTracks',numOfTracks:numOfTracks}));
+            } else if (timeRange ==='long_term' && allLongRangeTracks.length > 0){
+                dispatch(setCurrentTracks({timeRange:'allLongRangeTracks',numOfTracks:numOfTracks}));
+            } else{
+                dispatch(fetchTopTracks({timeRange:timeRange,numOfTracks:numOfTracks})); 
+            }
+            
         }, 500);
         return () => clearTimeout(delayChange);
-    },[dispatch,numOfTracks,timeRange]);
+    },[allLongRangeTracks.length, allShortRangeTracks.length, dispatch, numOfTracks, timeRange]);
 
 
     return(

--- a/src/components/LoggedInScreen.tsx
+++ b/src/components/LoggedInScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { useDispatch,useSelector } from "react-redux";
 import { AppDispatch } from "../app/store";
 import { selectNumOfTracks, selectTimeRange } from "../slices/filterButtonsSlice";
-import { fetchTopTracks, selectShowGraph } from "../slices/spotifySlice";
+import { fetchTopTracks, selectShowGraph, setCurrentTracks } from "../slices/spotifySlice";
 import Histogram from "./Histogram/Histogram";
 import NumOfTrackSlider from "./NumOfTrackSlider/NumNumOfTrackSlider";
 import SelectAudiFeature from "./SelectAudioFeature/SelectAudiFeature";
@@ -17,14 +17,16 @@ const LoggedInScreen = () => {
     const numOfTracks = useSelector(selectNumOfTracks);
     const showGraph = useSelector(selectShowGraph);
     
-    // handles deplaying api called based on filtered button change
     useEffect(() => {
-        // time out prevents too many API calls
+        dispatch(fetchTopTracks({timeRange}));     
+    },[dispatch,timeRange]);
+
+    useEffect(() => {
         const delayChange = setTimeout(() => {
-            dispatch(fetchTopTracks({timeRange,numOfTracks}))
+            dispatch(setCurrentTracks(numOfTracks));
         }, 500);
         return () => clearTimeout(delayChange);
-    },[dispatch,timeRange,numOfTracks]);
+    },[dispatch,numOfTracks]);
 
 
     return(

--- a/src/components/LoggedInScreen.tsx
+++ b/src/components/LoggedInScreen.tsx
@@ -23,10 +23,10 @@ const LoggedInScreen = () => {
 
     useEffect(() => {
         const delayChange = setTimeout(() => {
-            dispatch(setCurrentTracks(numOfTracks));
+            dispatch(setCurrentTracks({timeRange:timeRange,numOfTracks:numOfTracks}));
         }, 500);
         return () => clearTimeout(delayChange);
-    },[dispatch,numOfTracks]);
+    },[dispatch,numOfTracks,timeRange]);
 
 
     return(

--- a/src/components/TimeRangeButtons/TimeRangeButtons.tsx
+++ b/src/components/TimeRangeButtons/TimeRangeButtons.tsx
@@ -9,7 +9,7 @@ const TimeRangeButtons = () => {
 
     const handleChange = (event:React.MouseEvent<HTMLElement>,timeRangeString:string) => {
         if (timeRangeString === null){
-            timeRangeString = 'short_term'
+            timeRangeString = 'medium_term'
         }
         dispatch(setTimeRange(timeRangeString))
     }

--- a/src/components/TimeRangeButtons/TimeRangeButtons.tsx
+++ b/src/components/TimeRangeButtons/TimeRangeButtons.tsx
@@ -1,6 +1,7 @@
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "../../app/store";
 import { setTimeRange } from "../../slices/filterButtonsSlice";
+import { setCurrentAlbum } from "../../slices/spotifySlice";
 import TimeRangeButtonsComp from "./TimeRangeButtonsComp"
 
 const TimeRangeButtons = () => {
@@ -11,6 +12,7 @@ const TimeRangeButtons = () => {
         if (timeRangeString === null){
             timeRangeString = 'medium_term'
         }
+        dispatch(setCurrentAlbum(0))
         dispatch(setTimeRange(timeRangeString))
     }
 

--- a/src/slices/spotifySlice.ts
+++ b/src/slices/spotifySlice.ts
@@ -10,7 +10,8 @@ interface SpofityState {
     isLoggedIn:boolean;
     isLoading:boolean;
     showGraph:boolean;
-    allTracks:GenericObject[];
+    allShortRangeTracks:GenericObject[];
+    allMedRangeTracks:GenericObject[];
     tracks:GenericObject[];
     currentAlbum:number,
 }
@@ -100,7 +101,8 @@ const initialState = {
     isLoggedIn:false,
     isLoading:false,
     showGraph:false,
-    allTracks:[],
+    allShortRangeTracks:[],
+    allMedRangeTracks:[],
     tracks:[],
     currentAlbum:0,
 } as SpofityState;
@@ -128,14 +130,14 @@ const spotifySlice = createSlice({
         setCurrentAlbum(state,action){
             state.currentAlbum = action.payload;
         },
-        setCurrentTracks(state,action:PayloadAction<number>){
-            state.tracks = state.allTracks.slice(0,action.payload);
+        setCurrentTracks(state,action:PayloadAction<{timeRange:string,numOfTracks:number}>){
+            state.tracks = state[action.payload.timeRange as keyof typeof state].slice(0,action.payload.numOfTracks);
         }
     },
     extraReducers: (builder) => {
         builder
             .addCase(fetchTopTracks.fulfilled, (state, action) => {
-                state.allTracks = [...action.payload];
+                state.allMedRangeTracks = [...action.payload];
                 state.tracks = [...action.payload.slice(0,20)];
                 state.isLoading = false;
             })
@@ -151,6 +153,7 @@ export {fetchTopTracks,fetchTopAlbum};
 // states
 export const selectIsLoggedIn = (state: { spotifyAPI: { isLoggedIn: boolean; }; }) => state.spotifyAPI.isLoggedIn; 
 export const selectLoading = (state: { spotifyAPI: { isLoading: boolean; }; }) => state.spotifyAPI.isLoading;
+export const selectAllShortRangeTracks = (state: { spotifyAPI: { allShortRangeTracks: GenericObject[]; }; }) => state.spotifyAPI.allShortRangeTracks;
 export const selectTracks = (state: { spotifyAPI: { tracks: GenericObject[]; }; }) => state.spotifyAPI.tracks;
 export const selectCurrentAlbum = (state: { spotifyAPI: { currentAlbum: number; }; }) => state.spotifyAPI.currentAlbum;
 export const selectShowGraph = (state: { spotifyAPI: { showGraph: boolean; }; }) => state.spotifyAPI.showGraph; 


### PR DESCRIPTION
### What?
The goal of this update is to make less API call throughout the app. 

### Why? 
The app was call the API every time the user updated the UI. This was creating too many unnecessary API calls for the same data.

### How?
Now we call all 50 songs at once in a group and save the results to a all tracks state. The user pulls from the data already called but can limit how much they see. Also when the user calls a time range for the first time, it makes the API call then saves the results to the state. If the user toggles the data again then it goes back to the data stored from the first API call. 
