### PR TITLE
add check for "All Songs"

### DIFF
--- a/src/components/RadarChart/DataPoints.tsx
+++ b/src/components/RadarChart/DataPoints.tsx
@@ -39,7 +39,7 @@ const DataPoints = ({features, angleToCoordinate}:props) => {
                 defaultColor:themeColor.colorOne.color,
             }
             dispatch(setDataColors([colorObject]));
-        }else{
+        }else if(dataColors.find((color) => color.songTitle === 'All Songs')){
             const i = dataColors.findIndex((color) => color.songTitle === 'All Songs');
             dispatch(changeBothDataColors({index:i,color:themeColor.colorOne.color}))
         }


### PR DESCRIPTION
### What?
Fixed bug when users

1. Adds a song
2. Removes "All Songs"
3. Changes album

Doing the above steps would cause the app to crash. Bug was caused by app trying to "All songs" to color even though it did not exist. 

### How?
`seEffect(() => {
        if(dataColors.length === 0){
            const colorObject = {
                songTitle: "All Songs",
                currentColor: themeColor.colorOne.color,
                defaultColor:themeColor.colorOne.color,
            }
            dispatch(setDataColors([colorObject]));
        }else if(dataColors.find((color) => color.songTitle === 'All Songs')){
            const i = dataColors.findIndex((color) => color.songTitle === 'All Songs');
            dispatch(changeBothDataColors({index:i,color:themeColor.colorOne.color}))
        }
    },[themeColor.colorOne.color,dispatch])`


added: `else if(dataColors.find((color) => color.songTitle === 'All Songs'))`

to check if "All Songs" exist on the array when a user changes albums
If it does then update it the "All Songs" color to current album color
If is doesn't do nothing. 
