### PR TITLE
don't show hamburger if user is rejected

### DIFF
--- a/src/components/MenuBar/MenuBarComp.tsx
+++ b/src/components/MenuBar/MenuBarComp.tsx
@@ -7,7 +7,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import InfoIcon from '@mui/icons-material/Info';
 import { useSelector } from 'react-redux';
 import { selectThemeColors } from '../../slices/ThemeSlice';
-import { selectIsLoggedIn, selectShowGraph } from '../../slices/spotifySlice';
+import { selectIsLoggedIn, selectisRejected, selectShowGraph } from '../../slices/spotifySlice';
 
 interface MenuBarCompProps {
     handleMenuClick:() => void;
@@ -18,13 +18,14 @@ const MenuBarComp = ({handleMenuClick,handleInfoClick}:MenuBarCompProps) => {
 
     const themeColors = useSelector(selectThemeColors);
     const showGraph = useSelector(selectShowGraph);
-    const isLoggedIn = useSelector(selectIsLoggedIn)
+    const isLoggedIn = useSelector(selectIsLoggedIn);
+    const isRejected = useSelector(selectisRejected);
 
     return (
         <Box sx={{ flexGrow: 1 }}>
             <AppBar position="sticky">
                 <Toolbar>
-                    {isLoggedIn &&
+                    {isLoggedIn && !isRejected &&
                         <IconButton
                             size="large"
                             edge="start"


### PR DESCRIPTION
### What?
Made it so the hamburger menu will not show if the user is rejected.

### Why? 
A user clicking on the hamburger menu while rejected/ not able to log in would crash the whole app. 


